### PR TITLE
feat: add mdx files for services and about page

### DIFF
--- a/content/about/about-us.mdx
+++ b/content/about/about-us.mdx
@@ -1,0 +1,30 @@
+---
+title: About Us
+description: We empower genomic discovery through expert data analysis and investigator support.
+---
+
+<ContentSection title="About Us">
+  The Computational Biology Core (CBC) at Brown University provides essential computational support and expertise to advance research in human disease. We are a team dedicated to empowering researchers with the tools and knowledge needed to analyze complex biological data and make groundbreaking discoveries.
+
+  The CBC operates within a unique and collaborative structure at Brown, allowing us to leverage diverse resources and expertise:
+
+  - The CBC was established by the [Center for Computational Biology of Human Disease (CBHD)](https://sites.brown.edu/computational-biology-of-human-disease/), a center funded by a COBRE Institutional Development Award (IDeA) grant from the National Institute of General Medical Science. The CBHD's primary goal is to support and mentor junior investigators in human disease research that requiressignificant computational analysis of genomics data. We work directly with CBHD project leaders and pilot award recipients, providing the computational expertise to help them achieve their research aims. This includes creating standard analytical pipelines (e.g., for quality control and RNA Seqanalysis), developing customized analysis tools, and offer ingguidance on experimental design to ensure optimal data acquisition.
+
+  - The CBC is also a team within Brown University's [Center for Computation and Visualization (CCV)](https://ccv.brown.edu/), which is part of the Office of Information and Technology (OIT). The CCV's mission is to foster an environment where computational best practices, innovative solutions, and expert knowledge converge to build advanced research tools and enable new discoveries. This affiliation with the CCV strengthens our ability to provide cutting-edge computational solutions, taking full advantage of Brown's super-computing resources, research software engineering experience, and IT infrastructure resources. We embody the CCV's commitment to partnering with researchers, often through long-term collaborations.
+</ContentSection>
+
+<ContentSection title="Our Mission">
+  The primary mission of the Computational Biology Core (CBC) is to provide support to junior investigators in the analysis and interpretation of high-throughput DNA/RNA sequencing datasets, encompassing both internally generated and publicly accessible data. The Core is also committed to facilitating scientific collaboration among COBRE projects. The long-term objective of the CBC is to establish a sustainable resource that addresses the evolving data analysis needs of genomic research across Brown University and its affiliated hospitals, complemented by training initiatives to develop the next cohort of junior investigators.
+</ContentSection>
+
+<ContentSection title="Our Team">
+  <PeopleSection peopleContentPath="content/about/people.yaml" />
+</ContentSection>
+
+{/* This section is in /app/about/careers/page.tsx in the CCV website. Not sure if it will be the same structure in the CBC website or put in here.
+<ContentSection className="bg-neutral-50">
+  <ContentHeader>
+    <ContentTitle title="Opportunities" />
+  </ContentHeader>
+  <CareerData />
+</ContentSection> */}

--- a/content/services/services.mdx
+++ b/content/services/services.mdx
@@ -1,0 +1,91 @@
+---
+title: Services
+description: From office hours to collaborations, the CBC provides a range of services to support Brown's genomic research community.
+---
+
+<ContentSection title="Office Hours and Support">
+    Need help with your project or using Brown's computing resources? The CBC holds Computational Biology office hours twice weekly and is present at weekly Center for Computation and Visualization (CCV) office hours. Check our events schedule for upcoming times and locations.
+
+    Need more specialized support beyond office hours? Request a consultation with us.
+</ContentSection>
+
+<ContentSection title="Data Analysis">
+    The core provides assistance in experimental design and data processing pipelines for high-throughput datasets, particularly for DNA/RNA sequencing data. Our assistance falls broadly into the categories outlined below.
+
+    <CardGroup>
+        <StyledCard
+            title="Experimental Design and Power"
+            iconName="FaTools"
+        >
+            Conduct in silico experiments to assess power and sensitivity/specificity in the experimental design.
+        </StyledCard>
+
+        <StyledCard
+            title="Benchmarking"
+            iconName="FaRuler"
+        >
+            Use public and internal data for simulation studies to provide comprehensive prediction of possible outcomes to ensure efficient use of technologies.    
+        </StyledCard>
+
+        <StyledCard
+            title="Technological Assessment"
+            iconName="FaToolbox"
+        >
+            Provide guidance on technologies; for example, selection of single end/paired-end sequencing, multiplexing, sequencing depth, sample pooling etc.
+        </StyledCard>
+    </CardGroup>
+
+    <Button variant="primary_filled" href="mailto:cbc-help@brown.edu">Contact Us</Button>
+</ContentSection>
+
+<ContentSection title="Software Development & Infrastructure">
+    As part of Brown University's Center for Computation and Visualization (CCV), the CBC is uniquely equipped to meet the specialized software development and infrastructure needs of genomic research. We combine the CBC's deep biological and computational expertise with the CCV's research software engineering and high-performance computing (HPC) capabilities. This synergy provides comprehensive support tailored to genomic data analysis, empowering your research with cutting-edge software solutions, efficient data processing pipelines, and reliable computational infrastructure.
+
+    <CardGroup>
+        <StyledCard
+            title="Application Development"
+            iconName="FaDev"
+        >
+            The CBC and CCV can assist with the design, development, and optimization of custom software applications tailored to specific genomic research questions. This includes developing new tools for data analysis, visualization, or experimental design.    
+      </StyledCard>
+
+        <StyledCard
+            title="Web Apps"
+            iconName="FaGlobe"
+        >
+            We offer expertise in creating interactive web-based tools and applications for sharing  data, visualizing results, or providing user-friendly interfaces.   
+        </StyledCard>
+
+        <StyledCard
+            title="Packaging & Distribution"
+            iconName="FaBox"
+        >
+            We can help with packaging your tools, managing dependencies, and facilitating their distribution to the wider scientific community.
+        </StyledCard>
+
+        <StyledCard
+            title="Reproducibility"
+            iconName="FaShareAlt"
+        >
+            We can provide guidance and implement strategies for reproducible research workflows, including containerization, version control, and documentation.        
+        </StyledCard>
+
+        <StyledCard
+            title="Data Storage & Processing Pipelines"
+            iconName="FaDatabase"
+        >
+            We design and implement robust and scalable data storage solutions and processing pipelines optimized for large-scale genomic datasets, ensuring efficient data handling from raw reads to final analysis.   
+        </StyledCard>
+
+        <StyledCard
+            title="HPC Optimization"
+            iconName="FaMicrochip"
+        >
+            Provide guidance on technologies; for example, selection of single end/paired-end sequencing, multiplexing, sequencing depth, sample pooling etc.
+        </StyledCard>
+    </CardGroup>
+
+    Have an idea of how a collaboration with CBC can help achieve your computational research goals? We’d love to hear from you.
+
+    <Button variant="primary_filled" href="mailto:cbc-help@brown.edu">Contact Us</Button>
+</ContentSection>


### PR DESCRIPTION
This PR adds `services.mdx` and `about.mdx`, which will be used to generate page content after the components are pulled in from CCV website.